### PR TITLE
Correct nginx proxy Host header

### DIFF
--- a/docker/build/internal_files/clearml.conf.template
+++ b/docker/build/internal_files/clearml.conf.template
@@ -38,7 +38,7 @@ server {
 
     location /api {
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header Host $host;
+        proxy_set_header Host $proxy_host;
         proxy_pass ${NGINX_APISERVER_ADDR};
         rewrite /api/(.*) /$1  break;
     }


### PR DESCRIPTION
The Host header should be the target host not the source host. Fixes #209 