### PR TITLE
Webserver and fileserver parametric ports

### DIFF
--- a/docker/build/internal_files/clearml.conf.template
+++ b/docker/build/internal_files/clearml.conf.template
@@ -1,6 +1,6 @@
 server {
-    listen       80 default_server;
-    ${COMMENT_IPV6_LISTEN}listen       [::]:80 default_server;
+    listen       ${NGINX_WEBSERVER_PORT} default_server;
+    ${COMMENT_IPV6_LISTEN}listen       [::]:${NGINX_WEBSERVER_PORT} default_server;
     server_name  _;
     root         /usr/share/nginx/html;
     proxy_http_version 1.1;

--- a/docker/build/internal_files/entrypoint.sh
+++ b/docker/build/internal_files/entrypoint.sh
@@ -64,8 +64,9 @@ EOF
 
     export NGINX_APISERVER_ADDR=${NGINX_APISERVER_ADDRESS:-http://apiserver:8008}
     export NGINX_FILESERVER_ADDR=${NGINX_FILESERVER_ADDRESS:-http://fileserver:8081}
+    export NGINX_WEBSERVER_PORT=${NGINX_WEBSERVER_PORT:-80}
     export COMMENT_IPV6_LISTEN=$([ "$DISABLE_NGINX_IPV6" = "true" ] && echo "#" || echo "")
-    envsubst '${COMMENT_IPV6_LISTEN} ${NGINX_APISERVER_ADDR} ${NGINX_FILESERVER_ADDR}' < /etc/nginx/clearml.conf.template > /etc/nginx/sites-enabled/default
+    envsubst '${NGINX_WEBSERVER_PORT} ${COMMENT_IPV6_LISTEN} ${NGINX_APISERVER_ADDR} ${NGINX_FILESERVER_ADDR}' < /etc/nginx/clearml.conf.template > /etc/nginx/sites-enabled/default
 
     if [[ -n "${CLEARML_SERVER_SUB_PATH}" ]]; then
       mkdir -p /etc/nginx/default.d/
@@ -99,7 +100,7 @@ elif [[ ${SERVER_TYPE} == "fileserver" ]]; then
         -t "${FILESERVER_GUNICORN_TIMEOUT:-600}" --bind="${FILESERVER_GUNICORN_BIND:-0.0.0.0:8081}" \
         $MAX_REQUESTS fileserver:app
     else
-      python3 fileserver.py
+        python3 fileserver.py
     fi
 
 else

--- a/fileserver/config/default/fileserver.conf
+++ b/fileserver/config/default/fileserver.conf
@@ -1,30 +1,39 @@
-download {
-    # Add response headers requesting no caching for served files
-    disable_browser_caching: false
+{
+    debug: false            # Debug mode
+    
+    listen {
+        ip : "0.0.0.0"
+        port: 8081
+    }
 
-    # Cache timeout to be set for downloaded files
-    cache_timeout_sec: 300
-}
+    download {
+        # Add response headers requesting no caching for served files
+        disable_browser_caching: false
 
-delete {
-    allow_batch: true
-}
+        # Cache timeout to be set for downloaded files
+        cache_timeout_sec: 300
+    }
 
-upload {
-    # the max size in Mb of the upload contents in one upload call
-    max_upload_size_mb: 0
-}
+    delete {
+        allow_batch: true
+    }
 
-cors {
-    origins: "*"
-}
+    upload {
+        # the max size in Mb of the upload contents in one upload call
+        max_upload_size_mb: 0
+    }
 
-auth {
-    # enable/disable auth validation on upload/download
-    enabled: true
+    cors {
+        origins: "*"
+    }
 
-    # names of cookies in which authorization token can be found
-    cookie_names: ["clearml_token_basic"]
+    auth {
+        # enable/disable auth validation on upload/download
+        enabled: true
 
-    tokens_cache_threshold_sec: 43200
+        # names of cookies in which authorization token can be found
+        cookie_names: ["clearml_token_basic"]
+
+        tokens_cache_threshold_sec: 43200
+    }
 }

--- a/fileserver/fileserver.py
+++ b/fileserver/fileserver.py
@@ -201,12 +201,12 @@ if config.get("fileserver.delete.allow_batch"):
 def main():
     parser = ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--port", "-p", type=int, default=8081, help="Port (default %(default)d)"
+        "--port", "-p", type=int, default=config.get("fileserver.listen.port"), help="Port (default %(default)d)"
     )
     parser.add_argument(
-        "--ip", "-i", type=str, default="0.0.0.0", help="Address (default %(default)s)"
+        "--ip", "-i", type=str, default=config.get("fileserver.listen.ip"), help="Address (default %(default)s)"
     )
-    parser.add_argument("--debug", action="store_true", default=False)
+    parser.add_argument("--debug", action="store_true", default=config.get("fileserver.debug"))
     parser.add_argument(
         "--upload-folder",
         "-u",


### PR DESCRIPTION
# Motivation
This PR aims at making configurable all the ports that clearml-server uses.
Right now, some ports are hardcoded and not parametric ie webserver on port 80 and fileserver on port 8081.

# Fileserver port parameterization
The listening port for the fileserver is hardcoded in `fileserver/fileserver.py` (when launched via flask) and in `docker/build/internal_files/entrypoint.sh` (when launched via gunicorn).

## Flask setup
The code portion in `fileserver/fileserver.py` is reported below for simplicity.
```
    parser.add_argument(
        "--port", "-p", type=int, default=8081, help="Port (default %(default)d)"
   
    parser.add_argument(
        "--ip", "-i", type=str, default="0.0.0.0", help="Address (default %(default)s)"

    parser.add_argument("--debug", action="store_true", default=False)
```
I modified the fileserver to read the default values for ip, port and debug from the config and added the configurations inside of `fileserver/config/default/fileserver.conf`.
This behavior was guided by the existing mechanism in apiserver.

## Gunicorn setup
Similarly, I replicated the existing behavior of the apiserver to also make gunicorn configurable via environment variables.
The default port is preserved, while now it is also possible to override it with `FILESERVER_GUNICORN_BIND`.
The intended behavior is the same as the one used for the apiserver.

# Webserver port parameterization
The webserver port is hardcoded in `docker/build/internal_files/clearml.conf.template`.
```
    listen       80 default_server;
    ${COMMENT_IPV6_LISTEN}listen       [::]:80 default_server;
```
Per my understanding this is the conf that nginx uses to create the webserver UI, and it is not configurable via environment variables.
For this reason I modified the template to accepts an additional environment variable that allows to compile the webserver port via envsubst.
I also modified the envsubst command that is execute inside of `docker/build/internal_files/entrypoint.sh` to include such a value when the template is compiled.

# Testing
I tested the startup and basic interactions among those services.
I could not test (yet) more advanced features such as agents and pipeline runs.

If there is any known component that features hardcoded ports please highlight it so that I can improve my contribution